### PR TITLE
Replaced React.PropTypes reference with PropTypes

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -80,18 +80,18 @@ const Calendar = createReactClass({
   displayName: 'DatePickerCalendar',
 
   propTypes: {
-    selectedDate: React.PropTypes.object,
-    displayDate: React.PropTypes.object.isRequired,
-    minDate: React.PropTypes.string,
-    maxDate: React.PropTypes.string,
-    onChange: React.PropTypes.func.isRequired,
-    dayLabels: React.PropTypes.array.isRequired,
-    cellPadding: React.PropTypes.string.isRequired,
-    weekStartsOn: React.PropTypes.number,
-    showTodayButton: React.PropTypes.bool,
-    todayButtonLabel: React.PropTypes.string,
-    roundedCorners: React.PropTypes.bool,
-    showWeeks: React.PropTypes.bool
+    selectedDate: PropTypes.object,
+    displayDate: PropTypes.object.isRequired,
+    minDate: PropTypes.string,
+    maxDate: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    dayLabels: PropTypes.array.isRequired,
+    cellPadding: PropTypes.string.isRequired,
+    weekStartsOn: PropTypes.number,
+    showTodayButton: PropTypes.bool,
+    todayButtonLabel: PropTypes.string,
+    roundedCorners: PropTypes.bool,
+    showWeeks: PropTypes.bool
   },
 
   handleClick(day) {


### PR DESCRIPTION
<!--- Thank you for your pull request! This is a community supported 
project initially released by https://github.com/wehriam for your use
and enjoyment. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Replaced one area which was referencing `React.PropTypes` to use `PropTypes` from the `prop-types` library.

## Motivation and Context
Should fix PropTypes warnings which this library causes in itself, and other projects.

## How Has This Been Tested?
Test suite ran, PropTypes warning no longer appears in tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
