### PR TITLE
Revert bumps to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,11 @@
     "lint": "./node_modules/.bin/eslint --fix ./src/**"
   },
   "peerDependencies": {
-    "react": ">=15.6.1",
-    "react-bootstrap": ">=0.31.1"
+    "react": ">=14.0.0",
+    "react-bootstrap": ">=0.31.0"
   },
   "dependencies": {
-    "create-react-class": "^15.5.2",
-    "prop-types": "^15.5.9"
+    "create-react-class": "^15.5.2"
   },
   "devDependencies": {
     "assert": "^1.4.1",
@@ -63,6 +62,7 @@
     "mocha": "^3.2.0",
     "mocha-babel": "^3.0.3",
     "node-uuid": "^1.4.7",
+    "prop-types": "^15.5.9",
     "react": "^15.6.1",
     "react-bootstrap": "^0.31.1",
     "react-dom": "^15.5.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-bootstrap": ">=0.31.0"
   },
   "dependencies": {
-    "create-react-class": "^15.5.2"
+    "create-react-class": "^15.5.2",
+    "prop-types": "^15.5.9"
   },
   "devDependencies": {
     "assert": "^1.4.1",
@@ -62,7 +63,6 @@
     "mocha": "^3.2.0",
     "mocha-babel": "^3.0.3",
     "node-uuid": "^1.4.7",
-    "prop-types": "^15.5.9",
     "react": "^15.6.1",
     "react-bootstrap": "^0.31.1",
     "react-dom": "^15.5.4",


### PR DESCRIPTION
Reverted the specified versions of react & react-bootstrap (in peer dependencies).

Realised that previously they were too specific to a single use-case.